### PR TITLE
Extrapolate fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: flashier
 Type: Package
-Date: 2024-05-06
+Date: 2024-10-01
 Title: Empirical Bayes Matrix Factorization
-Version: 1.0.53
+Version: 1.0.54
 Authors@R: c(person("Jason", "Willwerscheid", role = c("aut", "cre"),
                     email = "jwillwer@providence.edu"),
              person("Peter", "Carbonetto", role = "aut"),

--- a/R/extrapolate.R
+++ b/R/extrapolate.R
@@ -13,10 +13,10 @@ set.extrapolate.param <- function(control) {
   return(par)
 }
 
-extrapolate <- function(new, old, beta, zero.k = NULL) {
+extrapolate <- function(new, old, beta, skip.cols = NULL) {
   res <- new + beta * (new - old)
-  if (!is.null(zero.k) && any(zero.k)) {
-    res[, which(zero.k)] <- 0
+  if (!is.null(skip.cols) && any(skip.cols)) {
+    res[, which(skip.cols)] <- new[, which(skip.cols)]
   }
   return(res)
 }
@@ -26,11 +26,12 @@ extrapolate.f <- function(f, old.f, par) {
   beta <- par$beta
   epsilon <- 1e-10
 
+  skip.cols <- is.zero(f)
   EF  <- mapply(extrapolate, get.EF(f), get.EF(old.f),
-                MoreArgs = list(beta = beta, zero.k = is.zero(f)),
+                MoreArgs = list(beta = beta, skip.cols = skip.cols),
                 SIMPLIFY = FALSE)
   EF2 <- mapply(extrapolate, get.EF2(f), get.EF2(old.f),
-                MoreArgs = list(beta = beta, zero.k = is.zero(f)),
+                MoreArgs = list(beta = beta, skip.cols = skip.cols),
                 SIMPLIFY = FALSE)
 
   # Ensure that EF2 > EF^2.

--- a/R/extrapolate.R
+++ b/R/extrapolate.R
@@ -13,8 +13,12 @@ set.extrapolate.param <- function(control) {
   return(par)
 }
 
-extrapolate <- function(new, old, beta) {
-  return(new + beta * (new - old))
+extrapolate <- function(new, old, beta, zero.k = NULL) {
+  res <- new + beta * (new - old)
+  if (!is.null(zero.k) && any(zero.k)) {
+    res[, which(zero.k)] <- 0
+  }
+  return(res)
 }
 
 # Works for both factor and flash objects.
@@ -23,9 +27,11 @@ extrapolate.f <- function(f, old.f, par) {
   epsilon <- 1e-10
 
   EF  <- mapply(extrapolate, get.EF(f), get.EF(old.f),
-                MoreArgs = list(beta = beta), SIMPLIFY = FALSE)
+                MoreArgs = list(beta = beta, zero.k = is.zero(f)),
+                SIMPLIFY = FALSE)
   EF2 <- mapply(extrapolate, get.EF2(f), get.EF2(old.f),
-                MoreArgs = list(beta = beta), SIMPLIFY = FALSE)
+                MoreArgs = list(beta = beta, zero.k = is.zero(f)),
+                SIMPLIFY = FALSE)
 
   # Ensure that EF2 > EF^2.
   EF2 <- mapply(function(EF, EF2) pmax(EF2, EF^2 + epsilon), EF, EF2,


### PR DESCRIPTION
Fixes issue where extrapolation was being done after columns had been set to zero (via the `is.zero` field), which caused them to no longer be zero (although `is.zero` remained `TRUE`).