### PR TITLE
Update flash_init.R

### DIFF
--- a/R/flash_init.R
+++ b/R/flash_init.R
@@ -22,8 +22,11 @@
 #'
 #' @export
 #'
-flash_init <- function(data, S = NULL, var_type = 0L, S_dim = NULL) {
+flash_init <- function(data, S = NULL, var_type = 0L, S_dim = NULL, Y2val = NULL) {
   flash <- set.flash.data(data, S = S, S.dim = S_dim, var.type = var_type)
+  if(!is.null(Y2val)) {
+    flash <- set.Y2(flash, Y2val)
+  }
 
   if (is.var.type.zero(flash) && !is.tau.simple(flash)) {
     flash$R <- flash$Y


### PR DESCRIPTION
A minor edit to allow `flash_init` to take a value for Y2 rather than have `flashier` compute it, which throws out the error `CHOLMOD error 'problem too large'` when the number of cells is too large (e.g., > 100k). 