### PR TITLE
Fix L_psd / F_psd: return SD, not variance, in 2-D wrapup path

### DIFF
--- a/R/wrapup.R
+++ b/R/wrapup.R
@@ -31,8 +31,8 @@ wrapup.flash <- function(flash, output.lvl) {
     if (get.dim(flash) == 2) {
       flash.object$L_pm  <- get.EF(flash)[[1]]
       flash.object$F_pm  <- get.EF(flash)[[2]]
-      flash.object$L_psd <- get.EF2(flash)[[1]] - get.EF(flash)[[1]]^2
-      flash.object$F_psd <- get.EF2(flash)[[2]] - get.EF(flash)[[2]]^2
+      flash.object$L_psd <- sqrt(pmax(get.EF2(flash)[[1]] - get.EF(flash)[[1]]^2, 0))
+      flash.object$F_psd <- sqrt(pmax(get.EF2(flash)[[2]] - get.EF(flash)[[2]]^2, 0))
       if (all.valid) {
         lfsr <- calc.lfsr(flash)
         if (is.matrix(lfsr[[1]])) {

--- a/tests/testthat/test_wrapup_psd.R
+++ b/tests/testthat/test_wrapup_psd.R
@@ -1,0 +1,19 @@
+context("wrapup posterior sd")
+
+# Regression test for L_psd / F_psd in the 2-D path:
+# the fields must return posterior SD, not posterior variance.
+
+test_that("L_psd / F_psd return posterior SD in 2-D path", {
+  set.seed(1)
+  n <- 200
+  p <- 50
+  Y <- matrix(rnorm(n * p), n, p) + tcrossprod(rnorm(n), rnorm(p))
+  fit <- flash(Y, greedy_Kmax = 1, verbose = 0)
+
+  samp <- fit$sampler(500)
+  sd_emp_L <- apply(simplify2array(lapply(samp, `[[`, 1L)), c(1, 2), sd)
+  sd_emp_F <- apply(simplify2array(lapply(samp, `[[`, 2L)), c(1, 2), sd)
+
+  expect_equal(median(as.numeric(fit$L_psd / sd_emp_L)), 1, tolerance = 0.10)
+  expect_equal(median(as.numeric(fit$F_psd / sd_emp_F)), 1, tolerance = 0.10)
+})


### PR DESCRIPTION
In `wrapup()` at `R/wrapup.R:34-35`, the 2-D path stores
`E[X^2] - E[X]^2` (posterior variance) in `$L_psd` / `$F_psd`. The fields
are documented as standard deviations (`R/flash.R:145-148`,
`man/flash.Rd:113-115`), and the >2-D path at `R/wrapup.R:52-56` already
applies `sqrt(pmax(., 0))`. This patch brings the 2-D path in line:

```r
flash.object$L_psd <- sqrt(pmax(get.EF2(flash)[[1]] - get.EF(flash)[[1]]^2, 0))
flash.object$F_psd <- sqrt(pmax(get.EF2(flash)[[2]] - get.EF(flash)[[2]]^2, 0))
```

## Reproduction

```r
library(flashier)
set.seed(1)
Y <- matrix(rnorm(200 * 50), 200, 50) + tcrossprod(rnorm(200), rnorm(50))
fit <- flash(Y, greedy_Kmax = 1, verbose = 0)
samp <- fit$sampler(500)
sd_emp <- apply(simplify2array(lapply(samp, `[[`, 1L)), c(1, 2), sd)
median(as.numeric(sqrt(fit$L_psd) / sd_emp))   # ~ 1.00
median(as.numeric(     fit$L_psd  / sd_emp))   # ~ sd_emp (i.e. variance)
```

## Test

`tests/testthat/test_wrapup_psd.R` asserts `$L_psd` and `$F_psd` match
per-cell empirical SD via the sampler. No existing tests covered these
fields. `grep -rE 'L_psd|F_psd' tests/` returns nothing. Full
`devtools::test()` passes locally with the patch applied (PASS 46 / FAIL 0).